### PR TITLE
Limit build to only VS 2019 until full pipeline is implemented

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-def lvVersions = ['2019', '2020']
+def lvVersions = ['2019']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
 diffPipeline(lvVersions[0])


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Limit building to only version 2019 until the full build pipeline is implemented. Because the Source/Addon/Support Libraries are statically included and built for 2019, these will fail the build for 2020.

### Why should this Pull Request be merged?

Get a working build in at least one version to begin testing a full pipeline build.

### What testing has been done?

Hand-built with the latest dependencies for 2019.
