### PR TITLE
Changed the path where the Protocols.lvlibp and Protections.lvlibp gets built

### DIFF
--- a/Source/Addon/Custom Device Instrument Addon.xml
+++ b/Source/Addon/Custom Device Instrument Addon.xml
@@ -13,7 +13,7 @@
     <Type>Action</Type>
     <Item2Launch>
       <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Initialization VI.vi</Path>
+		<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Initialization VI.vi</Path>
     </Item2Launch>
   </InitializationVI>
   <CustomDeviceVI>
@@ -22,7 +22,7 @@
 				<SupportedTarget>Windows</SupportedTarget>
 				<Source>
 					<Type>To Common Doc Dir</Type>
-					<Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Engine Windows.llb\RT Driver VI.vi</Path>
+					<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Engine Windows.llb\RT Driver VI.vi</Path>
 				</Source>
 				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Instrument Addon Engine Windows.llb\RT Driver VI.vi</RealTimeSystemDestination>
 			</Source>
@@ -30,7 +30,7 @@
 				<SupportedTarget>Pharlap</SupportedTarget>
 				<Source>
 					<Type>To Common Doc Dir</Type>
-					<Path>Custom Devices\Instrument Addon\Pharlap\Instrument Addon Engine Pharlap.llb\RT Driver VI.vi</Path>
+					<Path>Custom Devices\National Instruments\Instrument Addon\Pharlap\Instrument Addon Engine Pharlap.llb\RT Driver VI.vi</Path>
 				</Source>
 				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Instrument Addon Engine Pharlap.llb\RT Driver VI.vi</RealTimeSystemDestination>
 			</Source>
@@ -38,7 +38,7 @@
 				<SupportedTarget>Linux_32_ARM</SupportedTarget>
 				<Source>
 					<Type>To Common Doc Dir</Type>
-					<Path>Custom Devices\Instrument Addon\Linux_32_ARM\Instrument Addon Engine LinuxARM.llb\RT Driver VI.vi</Path>
+					<Path>Custom Devices\National Instruments\Instrument Addon\Linux_32_ARM\Instrument Addon Engine LinuxARM.llb\RT Driver VI.vi</Path>
 				</Source>
 				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Instrument Addon Engine LinuxARM.llb\RT Driver VI.vi</RealTimeSystemDestination>
 			</Source>
@@ -46,7 +46,7 @@
 				<SupportedTarget>Linux_x64</SupportedTarget>
 				<Source>
 					<Type>To Common Doc Dir</Type>
-					<Path>Custom Devices\Instrument Addon\Linux_x64\Instrument Addon Engine Linux64.llb\RT Driver VI.vi</Path>
+					<Path>Custom Devices\National Instruments\Instrument Addon\Linux_x64\Instrument Addon Engine Linux64.llb\RT Driver VI.vi</Path>
 				</Source>
 				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Instrument Addon Engine Linux64.llb\RT Driver VI.vi</RealTimeSystemDestination>
 			</Source>
@@ -57,7 +57,7 @@
       <SupportedTarget>Windows</SupportedTarget>
       <Source>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Protocols.lvlibp</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Protocols.lvlibp</Path>
       </Source>
       <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
     </Dependency>
@@ -65,7 +65,7 @@
       <SupportedTarget>Windows</SupportedTarget>
       <Source>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Protections.lvlibp</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Protections.lvlibp</Path>
       </Source>
       <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
     </Dependency>
@@ -73,7 +73,7 @@
       <SupportedTarget>Pharlap</SupportedTarget>
       <Source>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Pharlap\Protocols.lvlibp</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Pharlap\Protocols.lvlibp</Path>
       </Source>
       <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
     </Dependency>
@@ -81,7 +81,7 @@
       <SupportedTarget>Pharlap</SupportedTarget>
       <Source>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Pharlap\Protections.lvlibp</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Pharlap\Protections.lvlibp</Path>
       </Source>
       <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
     </Dependency>
@@ -89,7 +89,7 @@
       <SupportedTarget>Linux_x64</SupportedTarget>
       <Source>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Linux_x64\Protocols.lvlibp</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Linux_x64\Protocols.lvlibp</Path>
       </Source>
       <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
     </Dependency>
@@ -97,7 +97,7 @@
       <SupportedTarget>Linux_x64</SupportedTarget>
       <Source>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Linux_x64\Protections.lvlibp</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Linux_x64\Protections.lvlibp</Path>
       </Source>
       <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
     </Dependency>
@@ -105,7 +105,7 @@
       <SupportedTarget>Linux_32_ARM</SupportedTarget>
       <Source>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Linux_32_ARM\Protocols.lvlibp</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Linux_32_ARM\Protocols.lvlibp</Path>
       </Source>
       <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
     </Dependency>
@@ -113,7 +113,7 @@
       <SupportedTarget>Linux_32_ARM</SupportedTarget>
       <Source>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Linux_32_ARM\Protections.lvlibp</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Linux_32_ARM\Protections.lvlibp</Path>
       </Source>
       <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
     </Dependency>
@@ -127,11 +127,11 @@
 		<GUID>5a19fd09-df16-47f0-8250-c59b5cb8c757</GUID>
 		<Glyph>
 			<Type>To Common Doc Dir</Type>
-			<Path>Custom Devices\Instrument Addon\Windows\Glyphs\Instrument.png</Path>
+			<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Glyphs\Instrument.png</Path>
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Main Page.vi</Path>
+		<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Main Page.vi</Path>
       </Item2Launch>
         <RunTimeMenu>
           <MenuItem>
@@ -143,7 +143,7 @@
             </Name>
             <Item2Launch>
               <Type>To Common Doc Dir</Type>
-              <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\EnableDisable Main Page.vi</Path>
+              <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\EnableDisable Main Page.vi</Path>
             </Item2Launch>
           </MenuItem>
           <MenuItem>
@@ -155,7 +155,7 @@
             </Name>
             <Item2Launch>
               <Type>To Common Doc Dir</Type>
-              <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\ExportConfigurationToFile.vi</Path>
+              <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\ExportConfigurationToFile.vi</Path>
             </Item2Launch>
           </MenuItem>
           <MenuItem>
@@ -179,7 +179,7 @@
             </Name>
             <Item2Launch>
               <Type>To Common Doc Dir</Type>
-              <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New Message Group.vi</Path>
+              <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New Message Group.vi</Path>
             </Item2Launch>
           </MenuItem>
           <MenuItem>
@@ -236,15 +236,15 @@
       </ButtonList>
       <ActionVIOnLoad>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\ActionVIOnLoad - Version.vi</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\ActionVIOnLoad - Version.vi</Path>
       </ActionVIOnLoad>
       <ActionVIOnSave>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\ActionVIOnSave Check Errors.vi</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\ActionVIOnSave Check Errors.vi</Path>
       </ActionVIOnSave>
       <ActionVIOnCompile>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\ActionVIOnCompile.vi</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\ActionVIOnCompile.vi</Path>
       </ActionVIOnCompile>
     </Page>
     <Page>
@@ -255,11 +255,11 @@
       <GUID>02db78c0-2fa5-4cb3-bdc4-0f140d052e7d</GUID>
       <Glyph>
 			<Type>To Common Doc Dir</Type>
-			<Path>Custom Devices\Instrument Addon\Windows\Glyphs\Instrument_Disabled.png</Path>
+			<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Glyphs\Instrument_Disabled.png</Path>
       </Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Main Page.vi</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Main Page.vi</Path>
       </Item2Launch>
       <RunTimeMenu>
         <MenuItem>
@@ -271,7 +271,7 @@
           </Name>
           <Item2Launch>
             <Type>To Common Doc Dir</Type>
-            <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\EnableDisable Main Page.vi</Path>
+            <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\EnableDisable Main Page.vi</Path>
           </Item2Launch>
         </MenuItem>
         <MenuItem>
@@ -283,7 +283,7 @@
           </Name>
           <Item2Launch>
             <Type>To Common Doc Dir</Type>
-            <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\ExportConfigurationToFile.vi</Path>
+            <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\ExportConfigurationToFile.vi</Path>
           </Item2Launch>
         </MenuItem>
         <MenuItem>
@@ -307,7 +307,7 @@
           </Name>
           <Item2Launch>
             <Type>To Common Doc Dir</Type>
-            <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New Message Group.vi</Path>
+            <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New Message Group.vi</Path>
           </Item2Launch>
         </MenuItem>
         <MenuItem>
@@ -364,11 +364,11 @@
       </ButtonList>
       <ActionVIOnLoad>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\ActionVIOnLoad - Version.vi</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\ActionVIOnLoad - Version.vi</Path>
       </ActionVIOnLoad>
       <ActionVIOnSave>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\ActionVIOnSave Check Errors.vi</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\ActionVIOnSave Check Errors.vi</Path>
       </ActionVIOnSave>
     </Page>
  <Page>
@@ -384,7 +384,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-	    	<Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Message.vi</Path>
+	    	<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Message.vi</Path>
       </Item2Launch>
     <RunTimeMenu>
       <MenuItem>
@@ -428,7 +428,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-	    	<Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Global MetaData Channels.vi</Path>
+	    	<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Global MetaData Channels.vi</Path>
       </Item2Launch>
     <RunTimeMenu>
       <MenuItem>
@@ -440,7 +440,7 @@
         </Name>
         <Item2Launch>
           <Type>To Common Doc Dir</Type>
-          <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New MetaData Channel.vi</Path>
+          <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New MetaData Channel.vi</Path>
         </Item2Launch>
       </MenuItem>
       <MenuItem>
@@ -452,7 +452,7 @@
         </Name>
         <Item2Launch>
           <Type>To Common Doc Dir</Type>
-          <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New MetaData Array.vi</Path>
+          <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New MetaData Array.vi</Path>
         </Item2Launch>
       </MenuItem>
       <MenuItem>
@@ -548,7 +548,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Message Channels.vi</Path>
+		<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Message Channels.vi</Path>
       </Item2Launch>
     </Page>
 <Page>
@@ -565,7 +565,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Trigger Channel.vi</Path>
+		<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Trigger Channel.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -582,7 +582,7 @@
       </Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Enable Periodic.vi</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Enable Periodic.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -599,7 +599,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Error Channel.vi</Path>
+		<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Error Channel.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -616,7 +616,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Message Status Channel.vi</Path>
+		<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Message Status Channel.vi</Path>
       </Item2Launch>
     </Page>
     <Page>
@@ -633,7 +633,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Message Timestamp Channel.vi</Path>
+		<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Message Timestamp Channel.vi</Path>
       </Item2Launch>
     </Page>
 <Page>
@@ -649,7 +649,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		    <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Command.vi</Path>
+		    <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Command.vi</Path>
       </Item2Launch>
     <RunTimeMenu>
       <MenuItem>
@@ -661,7 +661,7 @@
         </Name>
         <Item2Launch>
           <Type>To Common Doc Dir</Type>
-          <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New MetaData Channel.vi</Path>
+          <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New MetaData Channel.vi</Path>
         </Item2Launch>
       </MenuItem>
       <MenuItem>
@@ -673,7 +673,7 @@
         </Name>
         <Item2Launch>
           <Type>To Common Doc Dir</Type>
-          <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New MetaData Array.vi</Path>
+          <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New MetaData Array.vi</Path>
         </Item2Launch>
       </MenuItem>
       <MenuItem>
@@ -780,7 +780,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		    <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Response.vi</Path>
+		    <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Response.vi</Path>
       </Item2Launch>
       <RunTimeMenu>
         <MenuItem>
@@ -792,7 +792,7 @@
           </Name>
           <Item2Launch>
             <Type>To Common Doc Dir</Type>
-            <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New Data Channel.vi</Path>
+            <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New Data Channel.vi</Path>
           </Item2Launch>
         </MenuItem>
         <MenuItem>
@@ -804,7 +804,7 @@
           </Name>
           <Item2Launch>
             <Type>To Common Doc Dir</Type>
-            <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New Data Array.vi</Path>
+            <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New Data Array.vi</Path>
           </Item2Launch>
         </MenuItem>
         <MenuItem>
@@ -911,7 +911,7 @@
 		</Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-		<Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Data Channel.vi</Path>
+		<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Data Channel.vi</Path>
       </Item2Launch>
     <RunTimeMenu>
       <MenuItem>
@@ -941,7 +941,7 @@
       </Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\MetaData Channel.vi</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\MetaData Channel.vi</Path>
       </Item2Launch>
       <RunTimeMenu>
         <MenuItem>
@@ -970,7 +970,7 @@
       </Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Message Group.vi</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Message Group.vi</Path>
       </Item2Launch>
       <RunTimeMenu>
         <MenuItem>
@@ -982,7 +982,7 @@
           </Name>
           <Item2Launch>
             <Type>To Common Doc Dir</Type>
-            <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New Message.vi</Path>
+            <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Add New Message.vi</Path>
           </Item2Launch>
         </MenuItem>
         <MenuItem>
@@ -1064,7 +1064,7 @@
       </Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Array Metadata ELement.vi</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Array Metadata ELement.vi</Path>
       </Item2Launch>
       <RunTimeMenu>
         <MenuItem>
@@ -1094,7 +1094,7 @@
       </Glyph>
       <Item2Launch>
         <Type>To Common Doc Dir</Type>
-        <Path>Custom Devices\Instrument Addon\Windows\Instrument Addon Configuration.llb\Array Data ELement.vi</Path>
+        <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Configuration.llb\Array Data ELement.vi</Path>
       </Item2Launch>
       <RunTimeMenu>
         <MenuItem>

--- a/Source/Addon/Custom Device Instrument Addon.xml
+++ b/Source/Addon/Custom Device Instrument Addon.xml
@@ -24,7 +24,7 @@
 					<Type>To Common Doc Dir</Type>
 					<Path>Custom Devices\National Instruments\Instrument Addon\Windows\Instrument Addon Engine Windows.llb\RT Driver VI.vi</Path>
 				</Source>
-				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Instrument Addon Engine Windows.llb\RT Driver VI.vi</RealTimeSystemDestination>
+				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Instrument Addon Engine Windows.llb\RT Driver VI.vi</RealTimeSystemDestination>
 			</Source>
 			<Source>
 				<SupportedTarget>Pharlap</SupportedTarget>
@@ -32,7 +32,7 @@
 					<Type>To Common Doc Dir</Type>
 					<Path>Custom Devices\National Instruments\Instrument Addon\Pharlap\Instrument Addon Engine Pharlap.llb\RT Driver VI.vi</Path>
 				</Source>
-				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Instrument Addon Engine Pharlap.llb\RT Driver VI.vi</RealTimeSystemDestination>
+				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Instrument Addon Engine Pharlap.llb\RT Driver VI.vi</RealTimeSystemDestination>
 			</Source>
 	  		<Source>
 				<SupportedTarget>Linux_32_ARM</SupportedTarget>
@@ -40,7 +40,7 @@
 					<Type>To Common Doc Dir</Type>
 					<Path>Custom Devices\National Instruments\Instrument Addon\Linux_32_ARM\Instrument Addon Engine LinuxARM.llb\RT Driver VI.vi</Path>
 				</Source>
-				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Instrument Addon Engine LinuxARM.llb\RT Driver VI.vi</RealTimeSystemDestination>
+				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Instrument Addon Engine LinuxARM.llb\RT Driver VI.vi</RealTimeSystemDestination>
 			</Source>
 			<Source>
 				<SupportedTarget>Linux_x64</SupportedTarget>
@@ -48,7 +48,7 @@
 					<Type>To Common Doc Dir</Type>
 					<Path>Custom Devices\National Instruments\Instrument Addon\Linux_x64\Instrument Addon Engine Linux64.llb\RT Driver VI.vi</Path>
 				</Source>
-				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Instrument Addon Engine Linux64.llb\RT Driver VI.vi</RealTimeSystemDestination>
+				<RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Instrument Addon Engine Linux64.llb\RT Driver VI.vi</RealTimeSystemDestination>
 			</Source>
     </SourceDistribution>
 	</CustomDeviceVI>
@@ -59,7 +59,7 @@
         <Type>To Common Doc Dir</Type>
         <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Protocols.lvlibp</Path>
       </Source>
-      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
+      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
     </Dependency>
     <Dependency>
       <SupportedTarget>Windows</SupportedTarget>
@@ -67,7 +67,7 @@
         <Type>To Common Doc Dir</Type>
         <Path>Custom Devices\National Instruments\Instrument Addon\Windows\Protections.lvlibp</Path>
       </Source>
-      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
+      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
     </Dependency>
       <Dependency>
       <SupportedTarget>Pharlap</SupportedTarget>
@@ -75,7 +75,7 @@
         <Type>To Common Doc Dir</Type>
         <Path>Custom Devices\National Instruments\Instrument Addon\Pharlap\Protocols.lvlibp</Path>
       </Source>
-      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
+      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
     </Dependency>
     <Dependency>
       <SupportedTarget>Pharlap</SupportedTarget>
@@ -83,7 +83,7 @@
         <Type>To Common Doc Dir</Type>
         <Path>Custom Devices\National Instruments\Instrument Addon\Pharlap\Protections.lvlibp</Path>
       </Source>
-      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
+      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
     </Dependency>
 	<Dependency>
       <SupportedTarget>Linux_x64</SupportedTarget>
@@ -91,7 +91,7 @@
         <Type>To Common Doc Dir</Type>
         <Path>Custom Devices\National Instruments\Instrument Addon\Linux_x64\Protocols.lvlibp</Path>
       </Source>
-      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
+      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
     </Dependency>
     <Dependency>
       <SupportedTarget>Linux_x64</SupportedTarget>
@@ -99,7 +99,7 @@
         <Type>To Common Doc Dir</Type>
         <Path>Custom Devices\National Instruments\Instrument Addon\Linux_x64\Protections.lvlibp</Path>
       </Source>
-      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
+      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
     </Dependency>
 		<Dependency>
       <SupportedTarget>Linux_32_ARM</SupportedTarget>
@@ -107,7 +107,7 @@
         <Type>To Common Doc Dir</Type>
         <Path>Custom Devices\National Instruments\Instrument Addon\Linux_32_ARM\Protocols.lvlibp</Path>
       </Source>
-      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
+      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Protocols.lvlibp</RealTimeSystemDestination>
     </Dependency>
     <Dependency>
       <SupportedTarget>Linux_32_ARM</SupportedTarget>
@@ -115,7 +115,7 @@
         <Type>To Common Doc Dir</Type>
         <Path>Custom Devices\National Instruments\Instrument Addon\Linux_32_ARM\Protections.lvlibp</Path>
       </Source>
-      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
+      <RealTimeSystemDestination>c:\ni-rt\NIVeriStand\Custom Devices\National Instruments\Instrument Addon\Protections.lvlibp</RealTimeSystemDestination>
     </Dependency>
   </Dependencies>
   <Pages>

--- a/Source/Instrument Addon.lvproj
+++ b/Source/Instrument Addon.lvproj
@@ -1252,7 +1252,7 @@
 				<Property Name="Destination[0].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="Destination[0].type" Type="Str">LLB</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">/Pharlap/data</Property>
+				<Property Name="Destination[1].path" Type="Path">/Pharlap</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="Destination[2].destName" Type="Str">PackedLibs</Property>
 				<Property Name="Destination[2].path" Type="Path">/Pharlap</Property>
@@ -1261,7 +1261,7 @@
 				<Property Name="Source[0].Container.applyProperties" Type="Bool">true</Property>
 				<Property Name="Source[0].Container.applySaveSettings" Type="Bool">true</Property>
 				<Property Name="Source[0].destinationIndex" Type="Int">0</Property>
-				<Property Name="Source[0].itemID" Type="Str">{1595C22F-ABE6-48BE-A13D-718293C63ACE}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{166F9729-E13F-48B6-8C29-057EBF3AEB53}</Property>
 				<Property Name="Source[0].properties[0].type" Type="Str">Run when opened</Property>
 				<Property Name="Source[0].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[0].properties[1].type" Type="Str">Allow debugging</Property>

--- a/Source/Instrument Addon.lvproj
+++ b/Source/Instrument Addon.lvproj
@@ -865,7 +865,7 @@
 				<Property Name="Destination[1].path" Type="Path">../Built/NI_AB_PROJECTNAME/Windows/Host Automation API</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
 				<Property Name="PackedLib_callersAdapt" Type="Bool">true</Property>
-				<Property Name="Source[0].itemID" Type="Str">{FBD4031F-CEEB-435D-AFC0-2DD85297BEC9}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{AEDE2046-E595-4F70-9666-E0270BA0E827}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib</Property>
@@ -890,22 +890,22 @@
 				<Property Name="Bld_excludeLibraryItems" Type="Bool">true</Property>
 				<Property Name="Bld_excludePolymorphicVIs" Type="Bool">true</Property>
 				<Property Name="Bld_excludeTypedefs" Type="Bool">true</Property>
-				<Property Name="Bld_localDestDir" Type="Path">../Built/Display Templates</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../Built/NI_AB_PROJECTNAME/Display Templates</Property>
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utilities/Copy .LLB to NI VeriStand dir.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{C8AB3C33-E20A-44E7-90D7-E2F3637DE2FC}</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Display Templates</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/NI_AB_PROJECTNAME/Display Templates</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Display Templates/Data</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/NI_AB_PROJECTNAME/Display Templates/Data</Property>
 				<Property Name="Destination[2].destName" Type="Str">Instrument Addon Workspace LLB</Property>
-				<Property Name="Destination[2].path" Type="Path">../Built/Display Templates/Instrument Workspace Object Support.llb</Property>
+				<Property Name="Destination[2].path" Type="Path">../Built/NI_AB_PROJECTNAME/Display Templates/Instrument Workspace Object Support.llb</Property>
 				<Property Name="Destination[2].type" Type="Str">LLB</Property>
 				<Property Name="DestinationCount" Type="Int">3</Property>
 				<Property Name="Source[0].Container.applyDestination" Type="Bool">true</Property>
 				<Property Name="Source[0].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{D47384E9-E1A0-49F9-938B-672B9632B6D9}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{AEDE2046-E595-4F70-9666-E0270BA0E827}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].Container.applyDestination" Type="Bool">true</Property>
 				<Property Name="Source[1].Container.applyProperties" Type="Bool">true</Property>
@@ -970,22 +970,22 @@
 				<Property Name="Bld_excludeLibraryItems" Type="Bool">true</Property>
 				<Property Name="Bld_excludePolymorphicVIs" Type="Bool">true</Property>
 				<Property Name="Bld_excludeTypedefs" Type="Bool">true</Property>
-				<Property Name="Bld_localDestDir" Type="Path">../Built/Workspace Tools/Instrument Tool</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../Built/NI_AB_PROJECTNAME/Workspace Tools/Instrument Tool</Property>
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utilities/Copy .LLB to NI VeriStand dir.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{01EF7FCC-6B96-4F26-A5FD-03ABDACD5F91}</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Workspace Tools/Instrument Tool</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/NI_AB_PROJECTNAME/Workspace Tools/Instrument Tool</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Workspace Tools/Instrument Tool/Data</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/NI_AB_PROJECTNAME/Workspace Tools/Instrument Tool/Data</Property>
 				<Property Name="Destination[2].destName" Type="Str">Instrument Tool Support</Property>
-				<Property Name="Destination[2].path" Type="Path">../Built/Workspace Tools/Instrument Tool/Instrument Tool Support.llb</Property>
+				<Property Name="Destination[2].path" Type="Path">../Built/NI_AB_PROJECTNAME/Workspace Tools/Instrument Tool/Instrument Tool Support.llb</Property>
 				<Property Name="Destination[2].type" Type="Str">LLB</Property>
 				<Property Name="DestinationCount" Type="Int">3</Property>
 				<Property Name="Source[0].Container.applyDestination" Type="Bool">true</Property>
 				<Property Name="Source[0].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{D47384E9-E1A0-49F9-938B-672B9632B6D9}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{AEDE2046-E595-4F70-9666-E0270BA0E827}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].Container.applyDestination" Type="Bool">true</Property>
 				<Property Name="Source[1].Container.applyProperties" Type="Bool">true</Property>
@@ -1059,7 +1059,7 @@
 				<Property Name="Bld_excludeInlineSubVIs" Type="Bool">true</Property>
 				<Property Name="Bld_excludeLibraryItems" Type="Bool">true</Property>
 				<Property Name="Bld_excludePolymorphicVIs" Type="Bool">true</Property>
-				<Property Name="Bld_localDestDir" Type="Path">../Built/Workspace Tools/Instrument Tool</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../Built/NI_AB_PROJECTNAME/Workspace Tools/Instrument Tool</Property>
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_modifyLibraryFile" Type="Bool">true</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utilities/Copy .LLB to NI VeriStand dir.vi</Property>
@@ -1067,13 +1067,13 @@
 				<Property Name="Bld_version.build" Type="Int">9</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Instrument Tool.exe</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/Workspace Tools/Instrument Tool/Instrument Tool.exe</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/NI_AB_PROJECTNAME/Workspace Tools/Instrument Tool/Instrument Tool.exe</Property>
 				<Property Name="Destination[0].preserveHierarchy" Type="Bool">true</Property>
 				<Property Name="Destination[0].type" Type="Str">App</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/Workspace Tools/Instrument Tool/data</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/NI_AB_PROJECTNAME/Workspace Tools/Instrument Tool/data</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{017398A6-F806-439D-96C1-011D995812A9}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{AEDE2046-E595-4F70-9666-E0270BA0E827}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Tool.lvlib/Instrument - Tool.vi</Property>

--- a/Source/Instrument Addon.lvproj
+++ b/Source/Instrument Addon.lvproj
@@ -1245,7 +1245,7 @@
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utilities/Copy .LLB to NI VeriStand dir.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{FB085711-B7CD-49CE-AB6A-241C33E6676C}</Property>
 				<Property Name="Bld_targetDestDir" Type="Path">/Pharlap/Instrument Addon Engine Pharlap.llb</Property>
-				<Property Name="Bld_version.build" Type="Int">36</Property>
+				<Property Name="Bld_version.build" Type="Int">37</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
 				<Property Name="Destination[0].path" Type="Path">/Pharlap/Instrument Addon Engine Pharlap.llb</Property>

--- a/Source/Instrument Addon.lvproj
+++ b/Source/Instrument Addon.lvproj
@@ -610,7 +610,7 @@
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
 				<Property Name="Destination[0].path" Type="Path">../Built/NI_AB_PROJECTNAME/Windows</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/NI_AB_PROJECTNAME/Windows/Data</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/NI_AB_PROJECTNAME/Windows</Property>
 				<Property Name="Destination[2].destName" Type="Str">Instrument Addon Configuration LLB</Property>
 				<Property Name="Destination[2].path" Type="Path">../Built/NI_AB_PROJECTNAME/Windows/Instrument Addon Configuration.llb</Property>
 				<Property Name="Destination[2].type" Type="Str">LLB</Property>
@@ -624,7 +624,7 @@
 				<Property Name="DestinationCount" Type="Int">6</Property>
 				<Property Name="Source[0].Container.applyProperties" Type="Bool">true</Property>
 				<Property Name="Source[0].Container.applySaveSettings" Type="Bool">true</Property>
-				<Property Name="Source[0].itemID" Type="Str">{FBD4031F-CEEB-435D-AFC0-2DD85297BEC9}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{D47384E9-E1A0-49F9-938B-672B9632B6D9}</Property>
 				<Property Name="Source[0].properties[0].type" Type="Str">Run when opened</Property>
 				<Property Name="Source[0].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[0].properties[1].type" Type="Str">Allow debugging</Property>
@@ -726,7 +726,7 @@
 				<Property Name="DestinationCount" Type="Int">3</Property>
 				<Property Name="Source[0].Container.applyProperties" Type="Bool">true</Property>
 				<Property Name="Source[0].Container.applySaveSettings" Type="Bool">true</Property>
-				<Property Name="Source[0].itemID" Type="Str">{C869B8D8-12C3-4CA0-8441-3A3114A2891F}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{D47384E9-E1A0-49F9-938B-672B9632B6D9}</Property>
 				<Property Name="Source[0].properties[0].type" Type="Str">Run when opened</Property>
 				<Property Name="Source[0].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[0].properties[1].type" Type="Str">Allow debugging</Property>
@@ -905,13 +905,15 @@
 				<Property Name="DestinationCount" Type="Int">3</Property>
 				<Property Name="Source[0].Container.applyDestination" Type="Bool">true</Property>
 				<Property Name="Source[0].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{F1F98602-19FF-4B55-8FF0-5AA5971474BB}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{D47384E9-E1A0-49F9-938B-672B9632B6D9}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
+				<Property Name="Source[1].Container.applyDestination" Type="Bool">true</Property>
 				<Property Name="Source[1].Container.applyProperties" Type="Bool">true</Property>
 				<Property Name="Source[1].Container.applySaveSettings" Type="Bool">true</Property>
-				<Property Name="Source[1].itemID" Type="Ref"></Property>
+				<Property Name="Source[1].destinationIndex" Type="Int">2</Property>
+				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Addon/Instrument Addon Shared.lvlib/Shared</Property>
 				<Property Name="Source[1].properties[0].type" Type="Str">Remove front panel</Property>
-				<Property Name="Source[1].properties[0].value" Type="Bool">true</Property>
+				<Property Name="Source[1].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[1].properties[1].type" Type="Str">Remove block diagram</Property>
 				<Property Name="Source[1].properties[1].value" Type="Bool">true</Property>
 				<Property Name="Source[1].properties[2].type" Type="Str">Run when opened</Property>
@@ -922,62 +924,45 @@
 				<Property Name="Source[1].properties[4].value" Type="Bool">false</Property>
 				<Property Name="Source[1].propertiesCount" Type="Int">5</Property>
 				<Property Name="Source[1].type" Type="Str">Container</Property>
+				<Property Name="Source[10].Container.applyDestination" Type="Bool">true</Property>
+				<Property Name="Source[10].Container.depDestIndex" Type="Int">0</Property>
 				<Property Name="Source[10].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[10].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib</Property>
-				<Property Name="Source[10].Library.allowMissingMembers" Type="Bool">true</Property>
-				<Property Name="Source[10].type" Type="Str">Library</Property>
-				<Property Name="Source[11].Container.applyDestination" Type="Bool">true</Property>
-				<Property Name="Source[11].Container.depDestIndex" Type="Int">0</Property>
+				<Property Name="Source[10].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib/Type</Property>
+				<Property Name="Source[10].type" Type="Str">Container</Property>
 				<Property Name="Source[11].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[11].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib/Type</Property>
-				<Property Name="Source[11].type" Type="Str">Container</Property>
-				<Property Name="Source[12].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[12].itemID" Type="Ref">/My Computer/Addon/Instrument Addon Shared.lvlib</Property>
-				<Property Name="Source[12].Library.allowMissingMembers" Type="Bool">true</Property>
-				<Property Name="Source[12].type" Type="Str">Library</Property>
-				<Property Name="Source[2].Container.applyDestination" Type="Bool">true</Property>
-				<Property Name="Source[2].Container.applyProperties" Type="Bool">true</Property>
-				<Property Name="Source[2].Container.applySaveSettings" Type="Bool">true</Property>
+				<Property Name="Source[11].itemID" Type="Ref">/My Computer/Addon/Instrument Addon Shared.lvlib</Property>
+				<Property Name="Source[11].Library.allowMissingMembers" Type="Bool">true</Property>
+				<Property Name="Source[11].type" Type="Str">Library</Property>
 				<Property Name="Source[2].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[2].itemID" Type="Ref">/My Computer/Addon/Instrument Addon Shared.lvlib/Shared</Property>
-				<Property Name="Source[2].properties[0].type" Type="Str">Remove front panel</Property>
-				<Property Name="Source[2].properties[0].value" Type="Bool">false</Property>
-				<Property Name="Source[2].properties[1].type" Type="Str">Remove block diagram</Property>
-				<Property Name="Source[2].properties[1].value" Type="Bool">true</Property>
-				<Property Name="Source[2].properties[2].type" Type="Str">Run when opened</Property>
-				<Property Name="Source[2].properties[2].value" Type="Bool">false</Property>
-				<Property Name="Source[2].properties[3].type" Type="Str">Allow debugging</Property>
-				<Property Name="Source[2].properties[3].value" Type="Bool">false</Property>
-				<Property Name="Source[2].properties[4].type" Type="Str">Auto error handling</Property>
-				<Property Name="Source[2].properties[4].value" Type="Bool">false</Property>
-				<Property Name="Source[2].propertiesCount" Type="Int">5</Property>
-				<Property Name="Source[2].type" Type="Str">Container</Property>
+				<Property Name="Source[2].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Objects.lvlib</Property>
+				<Property Name="Source[2].Library.allowMissingMembers" Type="Bool">true</Property>
+				<Property Name="Source[2].type" Type="Str">Library</Property>
+				<Property Name="Source[3].Container.applyDestination" Type="Bool">true</Property>
 				<Property Name="Source[3].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[3].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Objects.lvlib</Property>
-				<Property Name="Source[3].Library.allowMissingMembers" Type="Bool">true</Property>
-				<Property Name="Source[3].type" Type="Str">Library</Property>
-				<Property Name="Source[4].Container.applyDestination" Type="Bool">true</Property>
-				<Property Name="Source[4].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[4].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib/SubVIs</Property>
-				<Property Name="Source[4].type" Type="Str">Container</Property>
-				<Property Name="Source[5].destinationIndex" Type="Int">0</Property>
-				<Property Name="Source[5].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Objects.lvlib/Instrument - Manual Object.vi</Property>
-				<Property Name="Source[5].sourceInclusion" Type="Str">Include</Property>
-				<Property Name="Source[5].type" Type="Str">VI</Property>
+				<Property Name="Source[3].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib/SubVIs</Property>
+				<Property Name="Source[3].type" Type="Str">Container</Property>
+				<Property Name="Source[4].destinationIndex" Type="Int">0</Property>
+				<Property Name="Source[4].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Objects.lvlib/Instrument - Manual Object.vi</Property>
+				<Property Name="Source[4].sourceInclusion" Type="Str">Include</Property>
+				<Property Name="Source[4].type" Type="Str">VI</Property>
+				<Property Name="Source[5].destinationIndex" Type="Int">2</Property>
+				<Property Name="Source[5].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib</Property>
+				<Property Name="Source[5].Library.allowMissingMembers" Type="Bool">true</Property>
+				<Property Name="Source[5].type" Type="Str">Library</Property>
 				<Property Name="Source[6].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[6].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib</Property>
-				<Property Name="Source[6].Library.allowMissingMembers" Type="Bool">true</Property>
-				<Property Name="Source[6].type" Type="Str">Library</Property>
+				<Property Name="Source[6].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Close Connection with CD.vi</Property>
+				<Property Name="Source[6].type" Type="Str">VI</Property>
 				<Property Name="Source[7].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[7].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Close Connection with CD.vi</Property>
+				<Property Name="Source[7].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Initialize Connection with CD.vi</Property>
 				<Property Name="Source[7].type" Type="Str">VI</Property>
 				<Property Name="Source[8].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[8].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Initialize Connection with CD.vi</Property>
+				<Property Name="Source[8].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Instrument Command Response.vi</Property>
 				<Property Name="Source[8].type" Type="Str">VI</Property>
 				<Property Name="Source[9].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[9].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Instrument Command Response.vi</Property>
-				<Property Name="Source[9].type" Type="Str">VI</Property>
-				<Property Name="SourceCount" Type="Int">13</Property>
+				<Property Name="Source[9].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib</Property>
+				<Property Name="Source[9].Library.allowMissingMembers" Type="Bool">true</Property>
+				<Property Name="Source[9].type" Type="Str">Library</Property>
+				<Property Name="SourceCount" Type="Int">12</Property>
 			</Item>
 			<Item Name="Workspace Tool" Type="Source Distribution">
 				<Property Name="Bld_buildCacheID" Type="Str">{38AA3848-69E7-4432-8DD1-9443FCC8B810}</Property>
@@ -1000,13 +985,15 @@
 				<Property Name="DestinationCount" Type="Int">3</Property>
 				<Property Name="Source[0].Container.applyDestination" Type="Bool">true</Property>
 				<Property Name="Source[0].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{F1F98602-19FF-4B55-8FF0-5AA5971474BB}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{D47384E9-E1A0-49F9-938B-672B9632B6D9}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
+				<Property Name="Source[1].Container.applyDestination" Type="Bool">true</Property>
 				<Property Name="Source[1].Container.applyProperties" Type="Bool">true</Property>
 				<Property Name="Source[1].Container.applySaveSettings" Type="Bool">true</Property>
-				<Property Name="Source[1].itemID" Type="Ref"></Property>
+				<Property Name="Source[1].destinationIndex" Type="Int">2</Property>
+				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Addon/Instrument Addon Shared.lvlib/Shared</Property>
 				<Property Name="Source[1].properties[0].type" Type="Str">Remove front panel</Property>
-				<Property Name="Source[1].properties[0].value" Type="Bool">true</Property>
+				<Property Name="Source[1].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[1].properties[1].type" Type="Str">Remove block diagram</Property>
 				<Property Name="Source[1].properties[1].value" Type="Bool">true</Property>
 				<Property Name="Source[1].properties[2].type" Type="Str">Run when opened</Property>
@@ -1018,65 +1005,48 @@
 				<Property Name="Source[1].propertiesCount" Type="Int">5</Property>
 				<Property Name="Source[1].type" Type="Str">Container</Property>
 				<Property Name="Source[10].destinationIndex" Type="Int">0</Property>
-				<Property Name="Source[10].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Tool.lvlib/Instrument - Tool.rtm</Property>
-				<Property Name="Source[10].lvfile" Type="Bool">true</Property>
+				<Property Name="Source[10].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Tool.lvlib/Instrument - Tool.vi</Property>
 				<Property Name="Source[10].sourceInclusion" Type="Str">Include</Property>
-				<Property Name="Source[11].destinationIndex" Type="Int">0</Property>
-				<Property Name="Source[11].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Tool.lvlib/Instrument - Tool.vi</Property>
-				<Property Name="Source[11].sourceInclusion" Type="Str">Include</Property>
-				<Property Name="Source[11].type" Type="Str">VI</Property>
+				<Property Name="Source[10].type" Type="Str">VI</Property>
+				<Property Name="Source[11].destinationIndex" Type="Int">2</Property>
+				<Property Name="Source[11].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Tool.lvlib</Property>
+				<Property Name="Source[11].Library.allowMissingMembers" Type="Bool">true</Property>
+				<Property Name="Source[11].type" Type="Str">Library</Property>
 				<Property Name="Source[12].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[12].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Tool.lvlib</Property>
+				<Property Name="Source[12].itemID" Type="Ref">/My Computer/Addon/Instrument Addon Shared.lvlib</Property>
 				<Property Name="Source[12].Library.allowMissingMembers" Type="Bool">true</Property>
 				<Property Name="Source[12].type" Type="Str">Library</Property>
-				<Property Name="Source[13].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[13].itemID" Type="Ref">/My Computer/Addon/Instrument Addon Shared.lvlib</Property>
-				<Property Name="Source[13].Library.allowMissingMembers" Type="Bool">true</Property>
-				<Property Name="Source[13].type" Type="Str">Library</Property>
 				<Property Name="Source[2].Container.applyDestination" Type="Bool">true</Property>
-				<Property Name="Source[2].Container.applyProperties" Type="Bool">true</Property>
-				<Property Name="Source[2].Container.applySaveSettings" Type="Bool">true</Property>
 				<Property Name="Source[2].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[2].itemID" Type="Ref">/My Computer/Addon/Instrument Addon Shared.lvlib/Shared</Property>
-				<Property Name="Source[2].properties[0].type" Type="Str">Remove front panel</Property>
-				<Property Name="Source[2].properties[0].value" Type="Bool">false</Property>
-				<Property Name="Source[2].properties[1].type" Type="Str">Remove block diagram</Property>
-				<Property Name="Source[2].properties[1].value" Type="Bool">true</Property>
-				<Property Name="Source[2].properties[2].type" Type="Str">Run when opened</Property>
-				<Property Name="Source[2].properties[2].value" Type="Bool">false</Property>
-				<Property Name="Source[2].properties[3].type" Type="Str">Allow debugging</Property>
-				<Property Name="Source[2].properties[3].value" Type="Bool">false</Property>
-				<Property Name="Source[2].properties[4].type" Type="Str">Auto error handling</Property>
-				<Property Name="Source[2].properties[4].value" Type="Bool">false</Property>
-				<Property Name="Source[2].propertiesCount" Type="Int">5</Property>
+				<Property Name="Source[2].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib/SubVIs</Property>
 				<Property Name="Source[2].type" Type="Str">Container</Property>
-				<Property Name="Source[3].Container.applyDestination" Type="Bool">true</Property>
 				<Property Name="Source[3].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[3].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib/SubVIs</Property>
-				<Property Name="Source[3].type" Type="Str">Container</Property>
+				<Property Name="Source[3].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib</Property>
+				<Property Name="Source[3].Library.allowMissingMembers" Type="Bool">true</Property>
+				<Property Name="Source[3].type" Type="Str">Library</Property>
 				<Property Name="Source[4].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[4].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib</Property>
-				<Property Name="Source[4].Library.allowMissingMembers" Type="Bool">true</Property>
-				<Property Name="Source[4].type" Type="Str">Library</Property>
+				<Property Name="Source[4].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Close Connection with CD.vi</Property>
+				<Property Name="Source[4].type" Type="Str">VI</Property>
 				<Property Name="Source[5].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[5].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Close Connection with CD.vi</Property>
+				<Property Name="Source[5].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Initialize Connection with CD.vi</Property>
 				<Property Name="Source[5].type" Type="Str">VI</Property>
 				<Property Name="Source[6].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[6].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Initialize Connection with CD.vi</Property>
+				<Property Name="Source[6].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Instrument Command Response.vi</Property>
 				<Property Name="Source[6].type" Type="Str">VI</Property>
 				<Property Name="Source[7].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[7].itemID" Type="Ref">/My Computer/APIs/Instrument Host Automation API.lvlib/Instrument Command Response.vi</Property>
-				<Property Name="Source[7].type" Type="Str">VI</Property>
+				<Property Name="Source[7].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib</Property>
+				<Property Name="Source[7].Library.allowMissingMembers" Type="Bool">true</Property>
+				<Property Name="Source[7].type" Type="Str">Library</Property>
+				<Property Name="Source[8].Container.applyDestination" Type="Bool">true</Property>
+				<Property Name="Source[8].Container.depDestIndex" Type="Int">0</Property>
 				<Property Name="Source[8].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[8].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib</Property>
-				<Property Name="Source[8].Library.allowMissingMembers" Type="Bool">true</Property>
-				<Property Name="Source[8].type" Type="Str">Library</Property>
-				<Property Name="Source[9].Container.applyDestination" Type="Bool">true</Property>
-				<Property Name="Source[9].Container.depDestIndex" Type="Int">0</Property>
-				<Property Name="Source[9].destinationIndex" Type="Int">2</Property>
-				<Property Name="Source[9].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib/Type</Property>
-				<Property Name="Source[9].type" Type="Str">Container</Property>
-				<Property Name="SourceCount" Type="Int">14</Property>
+				<Property Name="Source[8].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Shared.lvlib/Type</Property>
+				<Property Name="Source[8].type" Type="Str">Container</Property>
+				<Property Name="Source[9].destinationIndex" Type="Int">0</Property>
+				<Property Name="Source[9].itemID" Type="Ref">/My Computer/UIs/Instrument Workspace Tool.lvlib/Instrument - Tool.rtm</Property>
+				<Property Name="Source[9].lvfile" Type="Bool">true</Property>
+				<Property Name="Source[9].sourceInclusion" Type="Str">Include</Property>
+				<Property Name="SourceCount" Type="Int">13</Property>
 			</Item>
 			<Item Name="Workspace Tool EXE" Type="EXE">
 				<Property Name="App_copyErrors" Type="Bool">true</Property>

--- a/Source/Instrument Addon.lvproj
+++ b/Source/Instrument Addon.lvproj
@@ -726,7 +726,7 @@
 				<Property Name="DestinationCount" Type="Int">3</Property>
 				<Property Name="Source[0].Container.applyProperties" Type="Bool">true</Property>
 				<Property Name="Source[0].Container.applySaveSettings" Type="Bool">true</Property>
-				<Property Name="Source[0].itemID" Type="Str">{D47384E9-E1A0-49F9-938B-672B9632B6D9}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{AEDE2046-E595-4F70-9666-E0270BA0E827}</Property>
 				<Property Name="Source[0].properties[0].type" Type="Str">Run when opened</Property>
 				<Property Name="Source[0].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[0].properties[1].type" Type="Str">Allow debugging</Property>
@@ -850,7 +850,7 @@
 				<Property Name="Bld_excludeInlineSubVIs" Type="Bool">true</Property>
 				<Property Name="Bld_excludeLibraryItems" Type="Bool">true</Property>
 				<Property Name="Bld_excludePolymorphicVIs" Type="Bool">true</Property>
-				<Property Name="Bld_localDestDir" Type="Path">../Built/NI_AB_PROJECTNAME/Windows/Host Automation API</Property>
+				<Property Name="Bld_localDestDir" Type="Path">../Built/NI_AB_PROJECTNAME/Host Automation API</Property>
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_modifyLibraryFile" Type="Bool">true</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utilities/Copy .LLB to NI VeriStand dir.vi</Property>
@@ -858,11 +858,11 @@
 				<Property Name="Bld_version.build" Type="Int">49</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Instrument Host Automation API.lvlibp</Property>
-				<Property Name="Destination[0].path" Type="Path">../Built/NI_AB_PROJECTNAME/Windows/Host Automation API/Instrument Host Automation API.lvlibp</Property>
+				<Property Name="Destination[0].path" Type="Path">../Built/NI_AB_PROJECTNAME/Host Automation API/Instrument Host Automation API.lvlibp</Property>
 				<Property Name="Destination[0].preserveHierarchy" Type="Bool">true</Property>
 				<Property Name="Destination[0].type" Type="Str">App</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/NI_AB_PROJECTNAME/Windows/Host Automation API</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/NI_AB_PROJECTNAME/Host Automation API</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
 				<Property Name="PackedLib_callersAdapt" Type="Bool">true</Property>
 				<Property Name="Source[0].itemID" Type="Str">{AEDE2046-E595-4F70-9666-E0270BA0E827}</Property>

--- a/Source/Instrument Addon.lvproj
+++ b/Source/Instrument Addon.lvproj
@@ -720,13 +720,13 @@
 				<Property Name="Destination[0].path" Type="Path">../Built/NI_AB_PROJECTNAME/Windows/Instrument Addon Engine Windows.llb</Property>
 				<Property Name="Destination[0].type" Type="Str">LLB</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">../Built/NI_AB_PROJECTNAME/Windows/Data</Property>
+				<Property Name="Destination[1].path" Type="Path">../Built/NI_AB_PROJECTNAME/Windows</Property>
 				<Property Name="Destination[2].destName" Type="Str">Custom Device Directory</Property>
 				<Property Name="Destination[2].path" Type="Path">../Built/NI_AB_PROJECTNAME/Windows</Property>
 				<Property Name="DestinationCount" Type="Int">3</Property>
 				<Property Name="Source[0].Container.applyProperties" Type="Bool">true</Property>
 				<Property Name="Source[0].Container.applySaveSettings" Type="Bool">true</Property>
-				<Property Name="Source[0].itemID" Type="Str">{12AB958E-6128-46A8-ACA1-6EA7D5779863}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{C869B8D8-12C3-4CA0-8441-3A3114A2891F}</Property>
 				<Property Name="Source[0].properties[0].type" Type="Str">Run when opened</Property>
 				<Property Name="Source[0].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[0].properties[1].type" Type="Str">Allow debugging</Property>

--- a/build.toml
+++ b/build.toml
@@ -85,3 +85,4 @@ type = 'nipkg'
 payload_dir = 'Built'
 install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\National Instruments' 
 control_file = 'control'
+break

--- a/build.toml
+++ b/build.toml
@@ -85,5 +85,3 @@ type = 'nipkg'
 payload_dir = 'Built'
 install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\National Instruments' 
 control_file = 'control'
-
-break

--- a/build.toml
+++ b/build.toml
@@ -10,6 +10,38 @@ copy_location = 'Source\Addon\Support Libraries'
 path = 'Source\Instrument Addon.lvproj'
 
 [[build.steps]]
+name = 'Host API'
+type = 'lvBuildSpec'
+project = '{cd}'
+target = 'My Computer'
+build_spec = 'Host API'
+dependency_target = 'Windows'
+
+[[build.steps]]
+name = 'Workspace Object'
+type = 'lvBuildSpec'
+project = '{cd}'
+target = 'My Computer'
+build_spec = 'Host API'
+dependency_target = 'Windows'
+
+[[build.steps]]
+name = 'Workspace Tool'
+type = 'lvBuildSpec'
+project = '{cd}'
+target = 'My Computer'
+build_spec = 'Workspace Tool'
+dependency_target = 'Windows'
+
+[[build.steps]]
+name = 'Workspace Tool EXE'
+type = 'lvBuildSpec'
+project = '{cd}'
+target = 'My Computer'
+build_spec = 'Workspace Tool EXE'
+dependency_target = 'Windows'
+
+[[build.steps]]
 name = 'Configuration Library'
 type = 'lvBuildSpec'
 project = '{cd}'

--- a/build.toml
+++ b/build.toml
@@ -85,3 +85,5 @@ type = 'nipkg'
 payload_dir = 'Built'
 install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\National Instruments' 
 control_file = 'control'
+
+break

--- a/build.toml
+++ b/build.toml
@@ -10,38 +10,6 @@ copy_location = 'Source\Addon\Support Libraries'
 path = 'Source\Instrument Addon.lvproj'
 
 [[build.steps]]
-name = 'Host API'
-type = 'lvBuildSpec'
-project = '{cd}'
-target = 'My Computer'
-build_spec = 'Host API'
-dependency_target = 'Windows'
-
-[[build.steps]]
-name = 'Workspace Object'
-type = 'lvBuildSpec'
-project = '{cd}'
-target = 'My Computer'
-build_spec = 'Host API'
-dependency_target = 'Windows'
-
-[[build.steps]]
-name = 'Workspace Tool'
-type = 'lvBuildSpec'
-project = '{cd}'
-target = 'My Computer'
-build_spec = 'Workspace Tool'
-dependency_target = 'Windows'
-
-[[build.steps]]
-name = 'Workspace Tool EXE'
-type = 'lvBuildSpec'
-project = '{cd}'
-target = 'My Computer'
-build_spec = 'Workspace Tool EXE'
-dependency_target = 'Windows'
-
-[[build.steps]]
 name = 'Configuration Library'
 type = 'lvBuildSpec'
 project = '{cd}'

--- a/build.toml
+++ b/build.toml
@@ -85,4 +85,3 @@ type = 'nipkg'
 payload_dir = 'Built'
 install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\National Instruments' 
 control_file = 'control'
-break


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Changed the path where the Protocols.lvlibp and Protections.lvlip gets copied for Windows OS. Changed the CD Path in the xml from \Custom Devices\Instrument Addon to \Custom Devices\National Instruments\Instrument Addon

### Why should this Pull Request be merged?

Currently, installing the CD built on the build machine results in a series of errors in NI VeriStand due to incorrect paths.

### What testing has been done?

Tested the CD with these modifications and no errors were presented in NI VeriStand.
