### PR TITLE
Fixed PharLap dependency path issue

### DIFF
--- a/Source/Instrument Addon.lvproj
+++ b/Source/Instrument Addon.lvproj
@@ -563,10 +563,25 @@
 				<Item Name="Waveform Subtype Enum__ogtk__jki_vi_tester.ctl" Type="VI" URL="/&lt;vilib&gt;/addons/_JKI Toolkits/VI Tester/_support/Support.llb/Waveform Subtype Enum__ogtk__jki_vi_tester.ctl"/>
 				<Item Name="whitespace.ctl" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/whitespace.ctl"/>
 			</Item>
+			<Item Name="BuildHelpPath.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/BuildHelpPath.vi"/>
+			<Item Name="Check Special Tags.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Check Special Tags.vi"/>
+			<Item Name="Clear Errors.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Clear Errors.vi"/>
+			<Item Name="Convert property node font to graphics font.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Convert property node font to graphics font.vi"/>
+			<Item Name="Details Display Dialog.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Details Display Dialog.vi"/>
 			<Item Name="DOMUserDefRef.dll" Type="Document" URL="DOMUserDefRef.dll">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
+			<Item Name="Error Code Database.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Error Code Database.vi"/>
+			<Item Name="Find Tag.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Find Tag.vi"/>
+			<Item Name="Format Message String.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Format Message String.vi"/>
+			<Item Name="General Error Handler Core CORE.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/General Error Handler Core CORE.vi"/>
+			<Item Name="General Error Handler.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/General Error Handler.vi"/>
+			<Item Name="Get String Text Bounds.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Get String Text Bounds.vi"/>
+			<Item Name="Get Text Rect.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Get Text Rect.vi"/>
+			<Item Name="GetHelpDir.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/GetHelpDir.vi"/>
+			<Item Name="GetRTHostConnectedProp.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/GetRTHostConnectedProp.vi"/>
 			<Item Name="Instrument System Definition API.lvlib" Type="Library" URL="../APIs/System Definition API/Instrument System Definition API.lvlib"/>
+			<Item Name="Longest Line Length in Pixels.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Longest Line Length in Pixels.vi"/>
 			<Item Name="LV Config Read String.vi" Type="VI" URL="/&lt;resource&gt;/dialog/lvconfig.llb/LV Config Read String.vi"/>
 			<Item Name="lvanlys.dll" Type="Document" URL="/&lt;resource&gt;/lvanlys.dll"/>
 			<Item Name="mscorlib" Type="VI" URL="mscorlib">
@@ -593,9 +608,17 @@
 			<Item Name="nisyscfg.dll" Type="Document" URL="nisyscfg.dll">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
+			<Item Name="Not Found Dialog.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Not Found Dialog.vi"/>
+			<Item Name="Search and Replace Pattern.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Search and Replace Pattern.vi"/>
+			<Item Name="Set Bold Text.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Set Bold Text.vi"/>
+			<Item Name="Set String Value.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Set String Value.vi"/>
+			<Item Name="Simple Error Handler.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Simple Error Handler.vi"/>
 			<Item Name="systemLogging.dll" Type="Document" URL="systemLogging.dll">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
+			<Item Name="Three Button Dialog CORE.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Three Button Dialog CORE.vi"/>
+			<Item Name="Three Button Dialog.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Three Button Dialog.vi"/>
+			<Item Name="Trim Whitespace.vi" Type="VI" URL="../../Built/Display Templates/Instrument Workspace Object Support.llb/Trim Whitespace.vi"/>
 			<Item Name="VeriStandTestCase.lvclass" Type="LVClass" URL="../../../ni-master/niveristand-custom-device-testing-tools/VeriStandTestCase/VeriStandTestCase.lvclass"/>
 			<Item Name="VeriStandTestUtilities.lvlib" Type="Library" URL="../../../ni-master/niveristand-custom-device-testing-tools/VeriStandTestUtilities/VeriStandTestUtilities.lvlib"/>
 		</Item>
@@ -1257,7 +1280,7 @@
 				<Property Name="Destination[0].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="Destination[0].type" Type="Str">LLB</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
-				<Property Name="Destination[1].path" Type="Path">/Pharlap/data</Property>
+				<Property Name="Destination[1].path" Type="Path">/Pharlap</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="Destination[2].destName" Type="Str">PackedLibs</Property>
 				<Property Name="Destination[2].path" Type="Path">/Pharlap</Property>
@@ -1266,7 +1289,7 @@
 				<Property Name="Source[0].Container.applyProperties" Type="Bool">true</Property>
 				<Property Name="Source[0].Container.applySaveSettings" Type="Bool">true</Property>
 				<Property Name="Source[0].destinationIndex" Type="Int">0</Property>
-				<Property Name="Source[0].itemID" Type="Str">{1595C22F-ABE6-48BE-A13D-718293C63ACE}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{AB900D4B-5791-4C86-AAED-2AB9798B1290}</Property>
 				<Property Name="Source[0].properties[0].type" Type="Str">Run when opened</Property>
 				<Property Name="Source[0].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[0].properties[1].type" Type="Str">Allow debugging</Property>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The PharLap dependencies were copied on build into a folder called "data" which causing the VeriStand projects to fail on deploy.

### Why should this Pull Request be merged?

Currently, no system definition containing the custom device can be deployed because NI VeriStand can't locate the dependecies.

### What testing has been done?

Built the build specification locally, and verified if the files are placed to the expected directory.
