### PR TITLE
Moved the diffpipeline before the build step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,6 @@ def lvVersions = ['2018','2019','2020']
 
 List<String> dependencies = ['niveristand-instrument-addon-classes']
 
-ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions, dependencies)
 diffPipeline(lvVersions[0])
+ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions, dependencies)
+


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Moves the diffPipeline step before the build step so we can have diffed VIs before the build ends.

### Why should this Pull Request be merged?

Currently we have to wait until the build finishes (1+ hours) before the diffbot sends us the results of the diff.

### What testing has been done?

We apply the same pattern for FPGA Addon and it works with no problem.