### PR TITLE
Added Scripting API build specification to the build.toml file

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -10,6 +10,14 @@ copy_location = 'Source\Addon\Support Libraries'
 path = 'Source\Instrument Addon.lvproj'
 
 [[build.steps]]
+name = 'Scripting API'
+type = 'lvBuildSpec'
+project = '{cd}'
+target = 'My Computer'
+build_spec = 'Scripting API'
+dependency_target = 'Windows'
+
+[[build.steps]]
 name = 'Host API'
 type = 'lvBuildSpec'
 project = '{cd}'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds the "Scripting API" to the build.toml file

### Why should this Pull Request be merged?

The Scripting API build specification is currently not built as part of the IA CD

### What testing has been done?
n/a
