### PR TITLE
Added the package_output_dir = Source\Built line at the end of each package

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -93,11 +93,11 @@ type = 'nipkg'
 payload_dir = 'Built\IA'
 install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}' 
 control_file = 'control'
-package_output_dir = 'Source\Built'
+package_output_dir = 'Built'
 
 [[package]]
 type = 'nipkg'
 payload_dir = 'Built\Scripting'
 install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\Instrument Addon'
 control_file = 'control_scripting_api'
-package_output_dir = 'Source\Built'
+package_output_dir = 'Built'

--- a/build.toml
+++ b/build.toml
@@ -93,9 +93,11 @@ type = 'nipkg'
 payload_dir = 'Built\IA'
 install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}' 
 control_file = 'control'
+package_output_dir = 'Source\Built'
 
 [[package]]
 type = 'nipkg'
 payload_dir = 'Built\Scripting'
 install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\Instrument Addon'
 control_file = 'control_scripting_api'
+package_output_dir = 'Source\Built'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Added the package_output_dir = Source\Built line at the end of each package section so the installers will be built into a centralized folder

### Why should this Pull Request be merged?

The path to which the installers are copied after the build process is incorrect.

### What testing has been done?
n/a
