### PR TITLE
Fixed command/response deletion issue

### DIFF
--- a/Source/Addon/Custom Device Instrument Addon.xml
+++ b/Source/Addon/Custom Device Instrument Addon.xml
@@ -642,6 +642,7 @@
         <loc>Command</loc>
       </Name>
       <DisallowRenaming>true</DisallowRenaming>
+      <DeleteProtection>true</DeleteProtection>
       <GUID>9428600d-6a85-43b8-aaac-a755da7e0c9b</GUID>
       <Glyph>
 			<Type>To Application Data Dir</Type>
@@ -773,6 +774,7 @@
         <loc>Response</loc>
       </Name>
       <DisallowRenaming>true</DisallowRenaming>
+      <DeleteProtection>true</DeleteProtection>
       <GUID>e90b6266-233a-4552-94b4-54222f1875a2</GUID>
       <Glyph>
 			<Type>To Application Data Dir</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixed the issue where removing all Metadata/Data Channels also deleted the Command/Response section from the instrument addon. (System Explorer)

### Why should this Pull Request be merged?

Currently, when all Data/Metadata Channels are removed from the Response/Command section the section is also removed.

### What testing has been done?

Built the Custom Device using the updated xml document. Added a new IA CD in the system explorer and then Message Group->Message. Under Command/Response added Metadata Channels/Data Channels. Right click each section and selected the "Delete Multiple Items" option selecting all channels under the section. After the deletion the sections were not removed.
