### PR TITLE
Parent custom device under NI in menu

### DIFF
--- a/Source/Addon/Custom Device Instrument Addon.xml
+++ b/Source/Addon/Custom Device Instrument Addon.xml
@@ -2,8 +2,8 @@
 <CustomDevice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Custom Device.xsd">
 <XSDVersion Major="2010" Minor="0" Fix="0" Build="0" />
   <AddMenu>
-    <eng>National Instruments::Instrument Addon</eng>
-    <loc>National Instruments::Instrument Addon</loc>
+    <eng>NI::Instrument Addon</eng>
+    <loc>NI::Instrument Addon</loc>
   </AddMenu>
   <Version>1.5.4</Version>
   <Type>Inline HW Interface</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Make the custom device appear under the "NI" menu item, rather than "National Instruments".

### Why should this Pull Request be merged?

Branding update.

### What testing has been done?

N/A

