### PR TITLE
Only build engines once

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -54,7 +54,8 @@ dependency_target = 'Windows'
 
 [[build.steps]]
 name = 'Engine Libraries'
-type = 'lvBuildSpecAllTargets'
+type = 'lvBuildSpec'
+target = 'My Computer'
 project = '{cd}'
 build_spec = 'Engine Release'
 dependency_target = 'Windows'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Only build the engine code once for each target.

### Why should this Pull Request be merged?

The current `build.toml` file is building all the engines on the call to `lvBuildSpecAllTargets` and then building each of the other engines one more time.. This is building the engine 9 times instead of just the 5 times required and overloading all of our build machines.

### What testing has been done?

None
