### PR TITLE
Support installing packages dependent on LabVIEW 2021

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,5 +9,5 @@ def lvVersions = [
 
 List<String> dependencies = ['niveristand-instrument-addon-classes']
 
-diffPipeline(lvVersions[0])
+diffPipeline(lvVersions)
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions, dependencies)

--- a/build.toml
+++ b/build.toml
@@ -94,13 +94,13 @@ package_output_dir = 'Built'
 [[package]]
 type = 'nipkg'
 payload_dir = 'Built\Scripting'
-install_destination = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\Instrument Addon'
+install_destination = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\vi.lib\addons\VeriStand Custom Device Scripting APIs\Instrument Addon'
 control_file = 'control_scripting_api'
 package_output_dir = 'Built'
 
 [[package]]
 type = 'nipkg'
 payload_dir = 'Built\Scripting Examples'
-install_destination = 'ni-paths-LV{veristand_version}DIR\examples\NI VeriStand Custom Devices\Instrument Addon'
+install_destination = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\examples\NI VeriStand Custom Devices\Instrument Addon'
 control_file = 'control_scripting_examples'
 package_output_dir = 'Built'

--- a/control_scripting_api
+++ b/control_scripting_api
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Instrument Addon LabVIEW Support for NI VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0)

--- a/control_scripting_examples
+++ b/control_scripting_examples
@@ -11,8 +11,8 @@ XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
-XB-DisplayName: NI Instrument Addon LabVIEW Support for NI VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-instrument-addon-veristand-{veristand_version}-labview-support (>= {display_version})
+XB-DisplayName: NI Instrument Addon LabVIEW Examples for VeriStand {veristand_version}
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-instrument-addon-veristand-{veristand_version}-labview-support (>= {display_version})
 Replaces: ni-instrument-addon-veristand-{veristand_version}-labview-support-examples (<< 21.0.0)
 Conflicts: ni-instrument-addon-veristand-{veristand_version}-labview-support-examples (<< 21.0.0)
 Provides: ni-instrument-addon-veristand-{veristand_version}-labview-support-examples (= 21.0.0)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Support installing packages dependent on LabVIEW 2021 by targeting the correct bitness and package name.
Fix duplicated package name string between examples and scripting packages.

### Why should this Pull Request be merged?

Fix ATS execution by allowing 2021 scripting support to be installed.

### What testing has been done?

None.
