### PR TITLE
Bump version to 24.0.0, drop 2020 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,8 +24,6 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild: 
-        - version: '2020'
-          bitness: '32bit'
         - version: '2021'
           bitness: '64bit'
         - version: '2023'
@@ -85,7 +83,7 @@ stages:
           target: 'My Computer'
           buildSpec: 'Scripting Examples'
 
-      releaseVersion: '23.3.0'
+      releaseVersion: '24.0.0'
       buildOutputLocation: 'Source\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\instrument_addon_custom_device'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump the version to 24.0.0 and drop the automated build for VeriStand 2020.

I'm leaving the source in LabVIEW 2020 for now, so VeriStand 2020 builds are still possible locally.

### Why should this Pull Request be merged?

Necessary for a future release.

### What testing has been done?

N/A