### PR TITLE
Adding localization text in niveristand-instrument-addon-cd-LabVIEW- Support in control page

### DIFF
--- a/control_scripting_api
+++ b/control_scripting_api
@@ -13,3 +13,13 @@ Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: NI Instrument Addon LabVIEW Support for NI VeriStand {veristand_version}
 Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0)
+Description-zh-CN: 为NI VeriStand {veristand_version}提供LabVIEW对自定义设备的支持
+XB-DisplayName-zh-CN: NI Instrument Addon LabVIEW Support for NI VeriStand {veristand_version}
+Description-de: Stellt LabVIEW-Unterstützung für das Instrument-Zusatzpaket für benutzerdefinierte Geräte für NI VeriStand {veristand_version} bereit.
+XB-DisplayName-de: NI Instrument Addon - LabVIEW-Support für VeriStand {veristand_version}
+Description-fr: Fournit le support LabVIEW pour le périphérique personnalisé Instrument Addon pour NI VeriStand {veristand_version}
+XB-DisplayName-fr: NI Instrument Addon - Support LabVIEW pour NI VeriStand {veristand_version}
+Description-ja: NI VeriStand {veristand_version}用の計測器アドオンカスタムデバイスのLabVIEWサポートを提供します。
+XB-DisplayName-ja: NI Instrument Addon LabVIEWサポート - NI VeriStand {veristand_version}用
+Description-ko: NI VeriStand {veristand_version}을(를) 위한 Instrument Addon Custom Device의 LabVIEW 지원을 제공합니다.
+XB-DisplayName-ko: NI Instrument Addon LabVIEW 지원 - VeriStand {veristand_version} 지원


### PR DESCRIPTION

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

TODO: Include high-level description of the changes in this pull request.
As part of User Story (https://ni.visualstudio.com/DevCentral/_workitems/edit/2665528/) We are trying to include localization description for Chinese, German, Japanese, French, Korean languages for different VeriStand third party products.

TODO: Justify why this contribution should be part of the project.
Taken reference from VeriStand control page (‪\argo\ni\nipkg\pool\ni-v\ni-veristand-2024\24.0.0\24.0.0.49451-0+f299\ni-veristand-2024_24.0.0.49451-0+f299_windows_x64.nipkg.control) and edited niveristand-instruments-addon-cd-LabVIEW-Support control page accordingly.

TODO: Detail what testing has been done to ensure this submission meets requirements.
Testing is in progress
