### PR TITLE
[Instrument Addon CD] Errors compiling VeriStand Instrument Addon Custom Device manually

### DIFF
--- a/Source/Addon/Instrument Addon.lvproj
+++ b/Source/Addon/Instrument Addon.lvproj
@@ -1374,9 +1374,9 @@
 				<Property Name="Source[0].properties[2].type" Type="Str">Auto error handling</Property>
 				<Property Name="Source[0].properties[2].value" Type="Bool">false</Property>
 				<Property Name="Source[0].properties[3].type" Type="Str">Remove front panel</Property>
-				<Property Name="Source[0].properties[3].value" Type="Bool">true</Property>
+				<Property Name="Source[0].properties[3].value" Type="Bool">false</Property>
 				<Property Name="Source[0].properties[4].type" Type="Str">Remove block diagram</Property>
-				<Property Name="Source[0].properties[4].value" Type="Bool">true</Property>
+				<Property Name="Source[0].properties[4].value" Type="Bool">false</Property>
 				<Property Name="Source[0].propertiesCount" Type="Int">5</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>


### PR DESCRIPTION
- [ x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-instrument-addon-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- The manual build of the "Release Engine" specification for an Instrument Addon Custom Device targeting Linux is failing due to broken VIs in the Advanced System Definition API (Advanced sysdef library). This API was added as a dependency in the Project. So, Included Front Panels and Block Diagrams for the dependencies through Properties of Engine Release Build specs to avoid the building error.

### Why should this Pull Request be merged?

- This PR resolves the manual build failure in the "Release Engine" specification for Linux-targeted Instrument Addon Custom Device Project.

### What testing has been done?

- Manually triggered the Instrument Addon Custom Device pipeline targeting this PR branch, and it executed successfully without any errors. [Pipeline Link](https://ni.visualstudio.com/DevCentral/_build/results?buildId=11368392&view=results)
- Additionally, verified by manually building the "Release Engine" specifications.
